### PR TITLE
Support  for signTypedData

### DIFF
--- a/src/vms/evm/request.js
+++ b/src/vms/evm/request.js
@@ -82,6 +82,11 @@ let request = ({ blockchain, request, provider }) => {
 
     case 'eth_sign':
     case 'personal_sign':
+    case 'eth_signTypedData':
+    case 'eth_signTypedData_v1':
+    case 'eth_signTypedData_v2':
+    case 'eth_signTypedData_v3':
+    case 'eth_signTypedData_v4':
       return sign({ blockchain, params: request.params, provider })
       break
 


### PR DESCRIPTION
Example Usage:
```
    const sigUtil = require('eth-sig-util');
    const messageHex = sigUtil.signTypedData_v4(secret, {
      data:message
    })
    mock({
      blockchain: 'ethereum',
      accounts :{ return :accounts},
      signature: {
        params: [accounts[0], JSON.stringify(message)],
        return: messageHex
      }
    })
```