### PR TITLE
bug in method search in data.js

### DIFF
--- a/src/vms/evm/data.js
+++ b/src/vms/evm/data.js
@@ -7,7 +7,7 @@ let getContract = ({ address, api, provider }) => {
 
 let getContractFunction = ({ data, address, api, provider }) => {
   let contract = getContract({ address, api, provider })
-  let methodSelector = data.split('000000000000000000000000')[0]
+  let methodSelector = data.substring(0, 10);
   try {
     return contract.interface.getFunction(methodSelector)
   } catch (error) {


### PR DESCRIPTION
If the signature hash ends on a 0, split wont return the
correct value here eg, stakesFor(address) 0x25a1dfe0